### PR TITLE
jemalloc by default (2/5)

### DIFF
--- a/android/config.go
+++ b/android/config.go
@@ -1091,7 +1091,7 @@ func (c *config) EnableCFI() bool {
 }
 
 func (c *config) DisableScudo() bool {
-	return Bool(c.productVariables.DisableScudo)
+	return !Bool(c.productVariables.Malloc_use_scudo)
 }
 
 func (c *config) Android64() bool {

--- a/android/variable.go
+++ b/android/variable.go
@@ -70,6 +70,15 @@ type variableProperties struct {
 			Enabled *bool `android:"arch_variant"`
 		} `android:"arch_variant"`
 
+		Malloc_use_scudo struct {
+			Cflags              []string `android:"arch_variant"`
+			Shared_libs         []string `android:"arch_variant"`
+			Whole_static_libs   []string `android:"arch_variant"`
+			Exclude_static_libs []string `android:"arch_variant"`
+			Srcs                []string `android:"arch_variant"`
+			Header_libs         []string `android:"arch_variant"`
+		} `android:"arch_variant"`
+
 		Malloc_not_svelte struct {
 			Cflags              []string `android:"arch_variant"`
 			Shared_libs         []string `android:"arch_variant"`
@@ -269,6 +278,7 @@ type productVariables struct {
 	Unbundled_build_image        *bool    `json:",omitempty"`
 	Always_use_prebuilt_sdks     *bool    `json:",omitempty"`
 	Skip_boot_jars_check         *bool    `json:",omitempty"`
+	Malloc_use_scudo             *bool    `json:",omitempty"`
 	Malloc_not_svelte            *bool    `json:",omitempty"`
 	Malloc_zero_contents         *bool    `json:",omitempty"`
 	Malloc_pattern_fill_contents *bool    `json:",omitempty"`
@@ -301,8 +311,6 @@ type productVariables struct {
 	EnableCFI       *bool    `json:",omitempty"`
 	CFIExcludePaths []string `json:",omitempty"`
 	CFIIncludePaths []string `json:",omitempty"`
-
-	DisableScudo *bool `json:",omitempty"`
 
 	MemtagHeapExcludePaths      []string `json:",omitempty"`
 	MemtagHeapAsyncIncludePaths []string `json:",omitempty"`
@@ -522,6 +530,7 @@ func (v *productVariables) SetDefaultConfig() {
 		AAPTCharacteristics: stringPtr("nosdcard"),
 		AAPTPrebuiltDPI:     []string{"xhdpi", "xxhdpi"},
 
+		Malloc_use_scudo:             boolPtr(false),
 		Malloc_not_svelte:            boolPtr(true),
 		Malloc_zero_contents:         boolPtr(true),
 		Malloc_pattern_fill_contents: boolPtr(false),


### PR DESCRIPTION
Jemalloc by default is good because of  : 

1. Reduced Fragmentation: jemalloc employs sophisticated algorithms to allocate memory in a way that minimizes fragmentation. This fragmentation occurs when freed memory becomes scattered in small chunks, making it difficult to allocate larger blocks efficiently. jemalloc's approach helps maintain contiguous memory regions, leading to faster allocation and deallocation operations.

2. jemalloc excels in multi-threaded environments. It utilizes thread-caching mechanisms and per-thread allocation arenas to minimize contention and improve memory access speed for concurrent threads.

3. jemalloc provides valuable debugging features that can aid in troubleshooting memory-related issues within the operating system. These tools can help pinpoint memory leaks, identify memory usage patterns, and diagnose allocation/deallocation problems, leading to a more stable and reliable system.

4. It also make's the device perform well at higer  load's and improve performance. 


You can check other PR regarding this from these Links.  

[Build_soong](https://github.com/DerpFest-AOSP/build_soong/pull/6) (2/5)
[Bionic](https://github.com/DerpFest-AOSP/bionic/pull/3) (3/5)
[external_jemalloc_new](https://github.com/DerpFest-AOSP/external_jemalloc_new/pull/1) (4/5)
[manifest](https://github.com/DerpFest-AOSP/manifest/pulls/21) (5/5)