### PR TITLE
soong: Forbidden pkg-config again

### DIFF
--- a/ui/build/paths/config.go
+++ b/ui/build/paths/config.go
@@ -108,7 +108,6 @@ var Configuration = map[string]PathConfig{
 	"lsof":        Allowed,
 	"openssl":     Allowed,
 	"patch":       Allowed,
-	"pkg-config":  Allowed,
 	"pstree":      Allowed,
 	"python3":     Allowed,
 	"python3.6":   Allowed,
@@ -139,6 +138,7 @@ var Configuration = map[string]PathConfig{
 	"ld":         Forbidden,
 	"ld.bfd":     Forbidden,
 	"ld.gold":    Forbidden,
+	"pkg-config": Forbidden,
 
 	// These are toybox tools that only work on Linux.
 	"pgrep": LinuxOnlyPrebuilt,


### PR DESCRIPTION
* Fixes kernel build failure in Arch Linux due to missing header file error even if it exists

Log:
/home/someone5678/android/TheParasiteProject/kernel/sony/sm8550/scripts/dtc/yamltree.c:9:10: fatal error: 'yaml.h' file not found
         ^~~~~~~~

Change-Id: I5a1fab8f1d741eb2bcf7b1ca0279816e531a052d